### PR TITLE
Feature/setup route

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,6 +1,0 @@
-import { app } from './app';
-const port = 3000;
-
-app.listen(port, () => {
-    console.log('application is running');
-});

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,11 +1,15 @@
 import express from 'express';
 import cors from 'cors';
 import { runningMessage } from './index';
+import { GitHubRoute } from './routes/gitHub.route';
 
 export const app: express.Application = express();
+let gitHubRoute: GitHubRoute;
 
 app.use(express.json());
 app.use(cors());
+
+gitHubRoute = new GitHubRoute(app);
 
 app.get('/', (req: express.Request, res: express.Response) => {
     res.status(200).send(runningMessage);

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -1,8 +1,8 @@
 import express from 'express';
 import cors from 'cors';
+import { runningMessage } from './index';
 
 export const app: express.Application = express();
-const runningMessage = "Node application is running";
 
 app.use(express.json());
 app.use(cors());

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,0 +1,7 @@
+import { app } from './app';
+const port = 3000;
+export const runningMessage = `Node app running at http://localhost:${port}`;
+
+app.listen(port, () => {
+    console.log(runningMessage);
+});

--- a/api/src/models/gitHubPRRequest.model.ts
+++ b/api/src/models/gitHubPRRequest.model.ts
@@ -1,0 +1,3 @@
+export interface GitHubPRRequestModel {
+    gitHubUrl: string;
+}

--- a/api/src/routes/gitHub.route.ts
+++ b/api/src/routes/gitHub.route.ts
@@ -4,7 +4,7 @@ import { GitHubPRRequestModel } from '../models/gitHubPRRequest.model';
 
 export class GitHubRoute {
     private app: express.Application;
-    private regex = new RegExp('https:\/\/github.com\/([^\/]+)\/([^\/]+)');
+    private regex = new RegExp('https:\/\/github.com\/([^\/]+)\/([^\/\.]+)(\.git)*');
 
     constructor(app: express.Application) {
         this.app = app;

--- a/api/src/routes/gitHub.route.ts
+++ b/api/src/routes/gitHub.route.ts
@@ -24,7 +24,15 @@ export class GitHubRoute {
                         `https://api.github.com/repos/${matchArray[1]}/${matchArray[2]}/pulls`,
                         {headers: {'user-agent': 'node.js'}},
                         function(error, response, body) {
-                            res.status(200).json(body);
+                            if (error) {
+                                res.status(500).send();
+                            }
+                            else if (JSON.parse(body)?.message === "Not Found") {
+                                res.status(404).send();
+                            }
+                            else {
+                                res.status(200).json(body);
+                            }
                         }
                     );
                 }

--- a/api/src/routes/gitHub.route.ts
+++ b/api/src/routes/gitHub.route.ts
@@ -1,0 +1,37 @@
+import express from 'express'
+import request from 'request'
+import { GitHubPRRequestModel } from '../models/gitHubPRRequest.model';
+
+export class GitHubRoute {
+    private app: express.Application;
+    private regex = new RegExp('https:\/\/github.com\/([^\/]+)\/([^\/]+)');
+
+    constructor(app: express.Application) {
+        this.app = app;
+        this.configureRoutes();
+    }
+
+    private configureRoutes(): void {
+        this.app.post('/get-open-prs', (req: express.Request, res: express.Response) => {
+            const gitHubUrl = (req.body as GitHubPRRequestModel)?.gitHubUrl;
+            if (!gitHubUrl) {
+                res.status(400).send('invalid request');
+            }
+            else {
+                const matchArray = gitHubUrl.match(this.regex);
+                if (matchArray) {
+                    request.get(
+                        `https://api.github.com/repos/${matchArray[1]}/${matchArray[2]}/pulls`,
+                        {headers: {'user-agent': 'node.js'}},
+                        function(error, response, body) {
+                            res.status(200).json(body);
+                        }
+                    );
+                }
+                else {
+                    res.status(400).send('invalid request');
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
This PR sets up the route for the github open PR request.

Added a request model for the request which includes a githubURL
Added a regex to check githubURL which allows for optional .git at end of url
Added logic to parse the githubURL from request and determine if valid url
Sends error responses based on validity of request and response from github:
- If no valid githubUrl, returns 400
- If error from github call, returns 500
- If github responds with 200Ok, but not found, return 404